### PR TITLE
Fix 80mm receipt generation

### DIFF
--- a/admin/js/modules/pos.js
+++ b/admin/js/modules/pos.js
@@ -603,7 +603,11 @@ function toggleButtonLoading(button, isLoading, originalText) {
     
         const printBtn = document.getElementById('print-receipt-btn');
         toggleButtonLoading(printBtn, true, 'Print Small Receipt (80mm)');
-    
+
+        // Make the receipt data available before the iframe loads so the page
+        // inside the iframe can read it during its own DOMContentLoaded event.
+        localStorage.setItem('currentReceiptData', JSON.stringify(saleData));
+
         const iframe = document.createElement('iframe');
         // Hide the iframe completely so the user never sees it
         iframe.style.position = 'absolute';
@@ -616,11 +620,11 @@ function toggleButtonLoading(button, isLoading, originalText) {
             const base64Content = await new Promise((resolve, reject) => {
                 iframe.onload = async () => {
                     try {
-                        // Inject the sale data into the iframe's localStorage
-                        iframe.contentWindow.localStorage.setItem('currentReceiptData', JSON.stringify(saleData));
-                        
+                        // Prevent the page inside the iframe from opening its own print dialog
+                        iframe.contentWindow.print = () => {};
+
                         // Give the iframe's script time to render the receipt content
-                        await new Promise(r => setTimeout(r, 500)); 
+                        await new Promise(r => setTimeout(r, 500));
     
                         // a. Measure the actual height of the fully rendered receipt
                         const receiptBody = iframe.contentWindow.document.body;
@@ -660,8 +664,8 @@ function toggleButtonLoading(button, isLoading, originalText) {
                 };
     
                 // This starts the loading process
-                iframe.src = 'receipt-80mm.html';
                 document.body.appendChild(iframe);
+                iframe.src = 'receipt-80mm.html';
             });
     
             // Step 2: Send the generated Base64 PDF to the PrintNode API

--- a/admin/js/receipt-80mm.js
+++ b/admin/js/receipt-80mm.js
@@ -12,7 +12,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         const sale = JSON.parse(saleDataString);
         populateReceipt(sale);
-        setTimeout(() => window.print(), 500);
+        if (window.self === window.top) {
+            setTimeout(() => window.print(), 500);
+        }
     } catch (error) {
         console.error('Failed to render receipt:', error);
     }


### PR DESCRIPTION
## Summary
- avoid auto-print when 80mm receipt page is loaded inside an iframe
- set receipt data before loading the iframe
- disable print dialog in iframe and adjust loading order

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_688cf8003c2c832a85d5cd73f6263c83