### PR TITLE
Fix 80mm receipt generation

### DIFF
--- a/admin/css/receipt-80mm.css
+++ b/admin/css/receipt-80mm.css
@@ -18,7 +18,10 @@ body {
 }
 
 .receipt-header { text-align: center; margin-bottom: 10px; }
-.logo { width: 80px; margin-bottom: 5px; }
+.logo {
+    width: 50px; /* Smaller logo so it doesn't dominate the ticket */
+    margin-bottom: 5px;
+}
 .store-name { font-family: Moul; font-size: 1.1em; margin: 0; }
 .receipt-header p { margin: 2px 0; font-size: 0.9em; }
 

--- a/admin/js/receipt-80mm.js
+++ b/admin/js/receipt-80mm.js
@@ -12,7 +12,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         const sale = JSON.parse(saleDataString);
         populateReceipt(sale);
-        setTimeout(() => window.print(), 500);
+        if (window.self === window.top) {
+            setTimeout(() => window.print(), 500);
+        }
     } catch (error) {
         console.error('Failed to render receipt:', error);
     }


### PR DESCRIPTION
## Summary
- avoid auto-print when 80mm receipt page is loaded inside an iframe
- set receipt data before loading the iframe
- disable print dialog in iframe and adjust loading order
- shrink logo on 80mm receipt
- generate PDF with higher DPI and avoid page breaks
- calculate single continuous page height and disable margins

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_688cf8003c2c832a85d5cd73f6263c83